### PR TITLE
fix(schema): move vcl_trace to cdn.vcl_trace

### DIFF
--- a/src/coralogix/schema.js
+++ b/src/coralogix/schema.js
@@ -53,7 +53,6 @@ const schema = {
         ),
         end_msec: vcl`time.end.msec`,
         elapsed: '%D',
-        vcl_trace: str(vcl`req.http.x-trace`),
       },
       client: {
         name: str(vcl`client.as.name`),
@@ -134,6 +133,7 @@ const schema = {
         tcpi_delta_retrans: vcl`client.socket.tcpi_delta_retrans`,
         ploss: vcl`client.socket.ploss`,
       },
+      vcl_trace: str(vcl`req.http.x-trace`),
     },
   },
 };


### PR DESCRIPTION
I realised that `vcl_trace` is in the wrong location in the coralogix schema. I moved it to `cdn.vcl_trace`.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues


Thanks for contributing!
