### PR TITLE
fix: use status property before code

### DIFF
--- a/src/google/logger.js
+++ b/src/google/logger.js
@@ -15,6 +15,7 @@ const bigquery = require('./bigquery');
 const iam = require('./iam');
 const logs = require('../fastly/logs');
 const bigquerySchema = require('./schema');
+const { wrapError } = require('../util.js');
 
 const tablename = 'requests';
 const logconfigname = 'helix-logging';
@@ -27,7 +28,7 @@ async function add(params, fastlyClient, log) {
   const {
     email, key, service, project, version,
   } = params;
-  const { info, debug, error } = log;
+  const { info, debug } = log;
 
   try {
     const authclient = await auth.googleauth(email, key);
@@ -90,8 +91,7 @@ async function add(params, fastlyClient, log) {
       googleKeys.key,
     );
   } catch (e) {
-    error('Unable to set up Google BigQuery logging', e);
-    throw e;
+    throw wrapError('Unable to set up Google BigQuery logging', e);
   }
 }
 

--- a/src/util.js
+++ b/src/util.js
@@ -15,7 +15,7 @@ class StatusCodeError extends Error {
     super(msg ? `${msg}: ${e.message}` : e.message);
 
     this._detail = e;
-    this._status = e.code || e.statusCode || e.status || 500;
+    this._status = e.status || e.statusCode || e.code || 500;
   }
 
   get detail() {


### PR DESCRIPTION
Still getting an entry in the escalation channel, sigh!

Apparently, Fastly errors contain both a `code` and a `status` property, the former being a text description, and the `wrapError` function used them in the wrong order.